### PR TITLE
Add start on boot, make tools work on Core, build on snapcraft 3.9+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+parts/
+prime/
+stage/

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+mkdir -p ${SNAP_DATA}/socket
+
+snapctl stop --disable "${SNAP_INSTANCE_NAME}.daemon"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,6 +34,14 @@ apps:
     environment:
 #      WG_I_PREFER_BUGGY_USERSPACE_TO_POLISHED_KMOD: 1
       WG_SOCKET_DIR: $SNAP_DATA/socket
+  daemon:
+    daemon: oneshot
+    command: wg-quick up wg0
+    stop-command: wg-quick down wg0
+    plugs: [network, network-control, network-bind]
+    environment:
+      WG_SOCKET_DIR: $SNAP_DATA/socket
+
 
 parts:
   wireguard:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,17 +45,22 @@ parts:
     build-packages:
       - libmnl-dev
       - build-essential
+    override-pull: |
+      snapcraftctl pull
+      patch -p1 < $SNAPCRAFT_PROJECT_DIR/tools.patch
     stage-packages:
       - libc6
+      - libmnl0
     make-parameters: [WITH_WGQUICK=yes]
-  go:
-    source-tag: go1.13.7
   wireguard-go:
-    after: [go]
     plugin: make
     source-type: git
-    source: https://github.com/svet-b/wireguard-go.git
+    source: git://git.zx2c4.com/wireguard-go
     source-branch: v0.0.20200121
+    override-pull: |
+      snapcraftctl pull
+      patch -p1 < $SNAPCRAFT_PROJECT_DIR/svet.patch
+    build-snaps: [go]
 
 passthrough:
   layout:

--- a/svet.patch
+++ b/svet.patch
@@ -1,0 +1,87 @@
+From 7210e75af0b37d85247c9f0450569ff96e7ee9c7 Mon Sep 17 00:00:00 2001
+From: Svet Bajlekov <tomatoman@gmail.com>
+Date: Sun, 11 Nov 2018 03:27:06 +0100
+Subject: [PATCH] Implement WG_SOCKET_DIR environment variable
+
+---
+ ipc/uapi_bsd.go   | 12 ++++++++++--
+ ipc/uapi_linux.go | 12 ++++++++++--
+ 2 files changed, 20 insertions(+), 4 deletions(-)
+
+diff --git a/ipc/uapi_bsd.go b/ipc/uapi_bsd.go
+index 75cc0e3..3b8b5e7 100644
+--- a/ipc/uapi_bsd.go
++++ b/ipc/uapi_bsd.go
+@@ -18,8 +18,6 @@ import (
+ 	"golang.org/x/sys/unix"
+ )
+ 
+-var socketDirectory = "/var/run/wireguard"
+-
+ const (
+ 	IpcErrorIO        = -int64(unix.EIO)
+ 	IpcErrorProtocol  = -int64(unix.EPROTO)
+@@ -67,6 +65,11 @@ func (l *UAPIListener) Addr() net.Addr {
+ 
+ func UAPIListen(name string, file *os.File) (net.Listener, error) {
+ 
++	socketDirectory := os.Getenv("WG_SOCKET_DIR")
++	if socketDirectory == "" {
++		socketDirectory = "/var/run/wireguard"
++	}
++
+ 	// wrap file in listener
+ 
+ 	listener, err := net.FileListener(file)
+@@ -149,6 +152,11 @@ func UAPIListen(name string, file *os.File) (net.Listener, error) {
+ 
+ func UAPIOpen(name string) (*os.File, error) {
+ 
++	socketDirectory := os.Getenv("WG_SOCKET_DIR")
++	if socketDirectory == "" {
++		socketDirectory = "/var/run/wireguard"
++	}
++
+ 	// check if path exist
+ 
+ 	err := os.MkdirAll(socketDirectory, 0755)
+diff --git a/ipc/uapi_linux.go b/ipc/uapi_linux.go
+index a3c95ca..40ef354 100644
+--- a/ipc/uapi_linux.go
++++ b/ipc/uapi_linux.go
+@@ -16,8 +16,6 @@ import (
+ 	"golang.zx2c4.com/wireguard/rwcancel"
+ )
+ 
+-var socketDirectory = "/var/run/wireguard"
+-
+ const (
+ 	IpcErrorIO        = -int64(unix.EIO)
+ 	IpcErrorProtocol  = -int64(unix.EPROTO)
+@@ -65,6 +63,11 @@ func (l *UAPIListener) Addr() net.Addr {
+ 
+ func UAPIListen(name string, file *os.File) (net.Listener, error) {
+ 
++	socketDirectory := os.Getenv("WG_SOCKET_DIR")
++	if socketDirectory == "" {
++		socketDirectory = "/var/run/wireguard"
++	}
++
+ 	// wrap file in listener
+ 
+ 	listener, err := net.FileListener(file)
+@@ -146,6 +149,11 @@ func UAPIListen(name string, file *os.File) (net.Listener, error) {
+ 
+ func UAPIOpen(name string) (*os.File, error) {
+ 
++	socketDirectory := os.Getenv("WG_SOCKET_DIR")
++	if socketDirectory == "" {
++		socketDirectory = "/var/run/wireguard"
++	}
++
+ 	// check if path exist
+ 
+ 	err := os.MkdirAll(socketDirectory, 0755)
+-- 
+2.20.1
+

--- a/tools.patch
+++ b/tools.patch
@@ -1,0 +1,49 @@
+diff --git a/src/ipc.c b/src/ipc.c
+index b9d2532..3867fa0 100644
+--- a/src/ipc.c
++++ b/src/ipc.c
+@@ -77,6 +77,17 @@ static int string_list_add(struct string_list *list, const char *str)
+ }
+ 
+ #ifndef WINCOMPAT
++
++char *socket_dir = NULL;
++
++static char *get_socket_dir()
++{
++	if (socket_dir == NULL) {
++		socket_dir = strdup(getenv("WG_SOCKET_DIR"));
++	}
++	return socket_dir;
++}
++
+ static FILE *userspace_interface_file(const char *iface)
+ {
+ 	struct stat sbuf;
+@@ -87,7 +98,7 @@ static FILE *userspace_interface_file(const char *iface)
+ 	errno = EINVAL;
+ 	if (strchr(iface, '/'))
+ 		goto out;
+-	ret = snprintf(addr.sun_path, sizeof(addr.sun_path), SOCK_PATH "%s" SOCK_SUFFIX, iface);
++	ret = snprintf(addr.sun_path, sizeof(addr.sun_path), "%s/%s%s", get_socket_dir(), iface, SOCK_SUFFIX);
+ 	if (ret < 0)
+ 		goto out;
+ 	ret = stat(addr.sun_path, &sbuf);
+@@ -129,7 +140,7 @@ static bool userspace_has_wireguard_interface(const char *iface)
+ 
+ 	if (strchr(iface, '/'))
+ 		return false;
+-	if (snprintf(addr.sun_path, sizeof(addr.sun_path), SOCK_PATH "%s" SOCK_SUFFIX, iface) < 0)
++	if (snprintf(addr.sun_path, sizeof(addr.sun_path), "%s/%s%s", get_socket_dir(), iface, SOCK_SUFFIX) < 0)
+ 		return false;
+ 	if (stat(addr.sun_path, &sbuf) < 0)
+ 		return false;
+@@ -156,7 +167,7 @@ static int userspace_get_wireguard_interfaces(struct string_list *list)
+ 	char *end;
+ 	int ret = 0;
+ 
+-	dir = opendir(SOCK_PATH);
++	dir = opendir(get_socket_dir());
+ 	if (!dir)
+ 		return errno == ENOENT ? 0 : -errno;
+ 	while ((ent = readdir(dir))) {


### PR DESCRIPTION
Add a snap service so wireguard can start on boot. Copy the configuration to `/var/snap/wireguard-ammp/common/wg0.conf` and then `snap start --enable wireguard-ammp`.

Make the wireguard tools work on Core by making them look in the WG_SOCKET_DIR environment variable rather than assuming /var/run/wireguard.

Get the snap building under snapcraft 3.9+. These changes might affect building under snapcraft 2.

Apply patches to wireguard upstream git repos, rather than referencing a forked git repo.